### PR TITLE
chore: axios 호출 전역화(토큰 포함)

### DIFF
--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -5,6 +5,7 @@ import TeamCreateModal from "@/components/modals-sw/TeamCreateModal";
 import ProfileModal from "@/components/modals-sw/ProfileModal";
 import TeamJoinModal from "@/components/modals-sw/TeamJoinModal";
 import axios from "axios";
+import axiosWithAuthorization from "@/context/axiosWithAuthorization";
 import { ClipLoader } from "react-spinners"; 
 import * as S from "./home_s";
 import { useAlert } from "@/context/AlertContext";
@@ -33,46 +34,31 @@ export default function Home() {
     nickname: "",
     profileImageUrl: "",
   });
-
+  // 팀 멤버
   const [teamMembers, setTeamMembers] = useState({});
 
   const fetchProfile = async () => {
-    if (!accessToken) return;
     try {
-      const res = await axios.get(
-        `${homeUrl}/members/me`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }
-      );
-      console.log("프로필 응답:", res.data);
+      const res = await axiosWithAuthorization.get("/members/me");
+  
       setProfile({
         nickname: res.data.data.nickname || "",
         profileImageUrl: res.data.data.profileImageUrl || "",
       });
     } catch (error) {
-      showAlert("error", error.response.data.data.message);
-      console.log(error.response.data);
+      showAlert("error", error.response?.data?.data?.message || "프로필 조회 실패");
+      console.log(error.response?.data);
     }
-  }
-
-  useEffect(() => {fetchProfile()}, [accessToken]);
-
-
+  };
+  
   const fetchTeams = async () => {
-    if (!accessToken) return;
     if (isFetching || !hasMore) return; // 이미 요청 중이거나 더 이상 불러올 데이터 없으면 중단
 
     setIsFetching(true);
     try {
-      const res = await axios.get(
-        `${homeUrl}/teams/list`,
+      const res = await axiosWithAuthorization.get(
+        "/teams/list",
         {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
           params: {
             // 첫 페이지는 lastTeamId=null
             lastTeamId: lastTeamId,
@@ -103,7 +89,8 @@ export default function Home() {
         setHasMore(false);
       }
     } catch (error) {
-      console.error("팀 목록 조회 실패:", error.response?.data || error.message);
+      showAlert("error", error.response?.data?.data?.message || "팀 목록 조회 실패");
+      console.log(error.response?.data);
     } finally {
       setIsFetching(false);
     }
@@ -111,8 +98,7 @@ export default function Home() {
   const fetchTeamMembers = async (teamId) => {
     if (!accessToken) return;
     try {
-      const res = await axios.get(`${homeUrl}/members/${teamId}/list`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
+      const res = await axiosWithAuthorization.get(`/members/${teamId}/list`, {
         params: { size: 3 }, // 최대 3명만
       });
       const memberProfiles = res.data.data.content.map((m) => m.profileImageUrl);
@@ -123,20 +109,6 @@ export default function Home() {
       console.log(error.response.data);
     }
   };
-  useEffect(() => {
-    cards.forEach((team) => {
-      if (!teamMembers[team.teamId]) {
-        fetchTeamMembers(team.teamId);
-      }
-    });
-  }, [cards]);
-  
-  
-  // 첫 마운트 시 첫 페이지 로드
-  useEffect(() => {
-    fetchTeams();
-  }, [accessToken]);
-
   const handleScroll = () => {
     if (!hasMore || isFetching) return; // 더 이상 데이터 없거나 이미 요청 중이면 중단
 
@@ -146,17 +118,51 @@ export default function Home() {
       fetchTeams();
     }
   };
+  const handleMenuToggle = (id) => {
+    setSelectedId((prevId) => (prevId === id ? null : id));
+  };
+  const handleTeamAdded = () => {
+    //목록 상태를 초기화하거나, 페이지를 1로 되돌린 후 재요청
+    setLastTeamId(null);
+    setCards([]);
+    setHasMore(true);
+    fetchTeams();
+  };
+  const handleTeamDelete = async (teamId) => {
+    if (!accessToken) return;
+    try {
+      // DELETE /teams/{teamId}
+      await axios.delete(`${homeUrl}/teams/${teamId}`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      console.log(`팀(${teamId}) 삭제 성공`);
+  
+      //성공 시 로컬 상태에서 해당 팀 제거
+      setCards((prevCards) => prevCards.filter((team) => team.teamId !== teamId));
+    } catch (error) {
+      //에러
+      showAlert("error", error.response.data.data.message);
+      console.log(error.response.data);
+    }
+  };
 
+  // 첫 마운트 시 첫 페이지 로드
+  useEffect(() => {fetchProfile()}, [accessToken]);
+  useEffect(() => {fetchTeams();}, [accessToken]);
+  useEffect(() => {
+    cards.forEach((team) => {
+      if (!teamMembers[team.teamId]) {
+        fetchTeamMembers(team.teamId);
+      }
+    });
+}, [cards]);
   // 스크롤 이벤트 등록/해제
   useEffect(() => {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, [hasMore, isFetching]);
-
-
-  const handleMenuToggle = (id) => {
-    setSelectedId((prevId) => (prevId === id ? null : id));
-  };
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -173,32 +179,8 @@ export default function Home() {
     };
   }, [selectedId]);
 
-const handleTeamAdded = () => {
-    //목록 상태를 초기화하거나, 페이지를 1로 되돌린 후 재요청
-    setLastTeamId(null);
-    setCards([]);
-    setHasMore(true);
-    fetchTeams();
-  };
 
-const handleTeamDelete = async (teamId) => {
-  if (!accessToken) return;
-  try {
-    // DELETE /teams/{teamId}
-    await axios.delete(`${homeUrl}/teams/${teamId}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    console.log(`팀(${teamId}) 삭제 성공`);
 
-    // 성공 시, 로컬 상태에서 해당 팀 제거
-    setCards((prevCards) => prevCards.filter((team) => team.teamId !== teamId));
-  } catch (error) {
-    showAlert("error", error.response.data.data.message);
-    console.log(error.response.data);
-  }
-};
 
   return (
     <>

--- a/src/context/axiosWithAuthorization.js
+++ b/src/context/axiosWithAuthorization.js
@@ -1,0 +1,57 @@
+"use client";
+
+import axios from "axios";
+
+const axiosWithAuthorization = axios.create({   
+  baseURL: process.env.NEXT_PUBLIC_DEVFIT_SERVER_URI,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+//요청 인터셉터
+axiosWithAuthorization.interceptors.request.use(
+  (config) => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+//웅답 인터셉터
+axiosWithAuthorization.interceptors.response.use(
+  (response) => response, // 정상 응답은 그대로
+  async (error) => {
+    const originalRequest = error.config;
+
+    // accessToken 재발급 케이스: 401 응답에 새 토큰이 포함된 경우
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+
+      const newAccessToken = error.response.headers["Authorization"];
+      if (newAccessToken) {
+        // 새 토큰 저장
+        localStorage.setItem("accessToken", newAccessToken);
+        console.log("new Token"+newAccessToken)
+        //새 토큰으로 Authorization 재설정
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        //재시도
+        return axiosWithAuthorization(originalRequest);
+      }
+
+      //헤더에 토토이 없으면 로그인 페이지 리디렉
+      localStorage.removeItem("accessToken");
+      console.log("리프레시 토큰 만료")
+      // window.location.href = "/login";
+      return Promise.reject(error);
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosWithAuthorization;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #27 

---
## 📌 작업 내용 및 특이사항

- Axios Interceptor 구현
- 토큰 및 기본 헤더, baseURL 적용을 전역화하였습니다. 
- 토큰 만료 시 리프레시 토큰 확인하여 재요청 보내고, 리프레시 토큰까지 만료된 경우에는 로그인 화면으로 리디렉션하도록 수정했습니다. 
- 사용자 인증이 필요하지 않은 경우(로그인 필요하지 않은 경우-현재 서비스 상에는 존재하지 않지만 추후 해당 API 생성된다면) 기본 axios로 요청하면 됩니다.

---
## 📚 참고사항

-
